### PR TITLE
feat(setting): Implement the style part of password reset functionality

### DIFF
--- a/vue3/src/config/i18n/messages/setting/profile.ts
+++ b/vue3/src/config/i18n/messages/setting/profile.ts
@@ -36,6 +36,12 @@ export const i18nMessagesSettingPartProfilePart = {
     'zh-CN': () => '修改头像' as const,
     'zh-TW': () => '修改頭像' as const,
   },
+  // 设置页 个人信息 修改密码
+  settingProfileUpdatePasswordContentTitle: {
+    'en-US': () => 'Modify Password' as const,
+    'zh-CN': () => '修改密码' as const,
+    'zh-TW': () => '修改密碼' as const,
+  },
   // 设置页 个人信息 修改邮箱
   settingProfileUpdateEmailContentTitle: {
     'en-US': () => 'Update Email' as const,
@@ -104,5 +110,11 @@ export const i18nMessagesSettingPartProfilePart = {
     'en-US': (duration: string) => `Retry after ${duration}` as const,
     'zh-CN': (duration: string) => `${duration}后可重试` as const,
     'zh-TW': (duration: string) => `${duration}後可重試` as const,
+  },
+  // 设置页 个人信息 修改密码确认框
+  settingProfilePasswordConfirmContainerTitle: {
+    'en-US': (email: string) => `A password reset link will be sent to ${email}` as const,
+    'zh-CN': (email: string) => `密码重置链接将发送至 ${email}` as const,
+    'zh-TW': (email: string) => `密碼重置連結將發送至 ${email}` as const,
   },
 } as const satisfies I18nMessagesSatisfiesType

--- a/vue3/src/views/setting/views/SettingProfile.vue/components/UpdatePassword.vue
+++ b/vue3/src/views/setting/views/SettingProfile.vue/components/UpdatePassword.vue
@@ -1,0 +1,139 @@
+<script setup lang="ts">
+import type { GlobalComponents } from 'vue'
+import {
+  queryRetryPbNetworkError,
+  usePbCollectionConfigQuery,
+  useProfileQuery,
+} from '@/queries'
+import { useI18nStore, useSettingStateStore } from '@/stores'
+import { useMutation } from '@tanstack/vue-query'
+import { Collections, onPbResErrorStatus401AuthClear, pb } from '@/lib'
+import {
+  convertSecondsToTimeDuration,
+  fetchWithTimeoutForPbRequestWillEmail,
+  parseISODate,
+  potoMessage,
+} from '@/utils'
+import { useNow } from '@vueuse/core'
+import { pbCollectionConfigDefaultGetFn } from '@/config'
+
+const i18nStore = useI18nStore()
+
+// 查询
+const profileQuery = useProfileQuery()
+// 确认
+const refConfirmContainer = ref<InstanceType<
+  GlobalComponents['ConfirmContainer']
+> | null>(null)
+
+// 邮箱请求
+const mutation = useMutation({
+  mutationFn: async () => {
+    // 未登录，照搬
+    if (!pb.authStore.isValid || pb.authStore.record?.id == null) {
+      throw new Error(
+        '!pb.authStore.isValid || pb.authStore.record?.id == null'
+      )
+    }
+    // 无个人信息，照搬
+    if (profileQuery.data.value == null) {
+      throw new Error('!profileQuery.data.value == null')
+    }
+
+    // pocketbase SDK
+    const pbRes = await pb
+      .collection(Collections.Users)
+      .requestPasswordReset(profileQuery.data.value.email, {
+      fetch: fetchWithTimeoutForPbRequestWillEmail,
+      })
+    console.log(pbRes)
+    return pbRes
+  },
+  // 网络错误
+  retry: queryRetryPbNetworkError,
+  onError: (error) => {
+    // 出现鉴权失败则清除authStore
+    onPbResErrorStatus401AuthClear(error)
+    // 未知错误
+    potoMessage({
+      type: 'error',
+      message: i18nStore.t('messageUpdateFailure')(),
+    })
+  },
+  // 收尾
+  onSuccess: (data) => {
+    potoMessage({
+        type: 'success',
+        message: i18nStore.t('messageUpdateSuccess')(), 
+    })
+  },
+})
+
+const submitRunning = ref(false)
+// 验证邮箱
+const submit = async () => {
+  submitRunning.value = true
+  try {
+    await profileQuery.refetch()
+    await refConfirmContainer.value?.confirm()
+    await mutation.mutateAsync().catch(() => {})
+
+
+// 等 haruki 添加新的 loding 方法
+
+
+  } finally {
+    submitRunning.value = false
+  }
+}
+</script>
+
+<template>
+  <!-- 修改密码 -->
+  <div>
+    <ConfirmContainer
+      size="small"
+      ref="refConfirmContainer"
+      backgroundColorTwcss="bg-color-background-soft"
+      :title="
+        i18nStore.t('settingProfilePasswordConfirmContainerTitle')(
+        profileQuery.data.value?.email ?? '')">
+      <!-- 标题 -->
+      <div class="mb-3 ml-3 text-sm font-bold text-color-text-soft">
+        <!-- 修改密码 -->
+         {{ i18nStore.t('settingProfileUpdatePasswordContentTitle')() }}
+      </div>
+      <!-- 按钮 -->
+      <div class="poto-setting-button-box not-center">
+        <ElButton
+          :loading="submitRunning"
+          :disabled="emailVerifyRateLimitInfo != null"
+          type="primary"
+          round
+          @click="submit()"
+        >
+          <template v-if="emailVerifyRateLimitInfo != null">
+            <!-- 显示：xx 秒后可重试 -->
+            {{
+              i18nStore.t('settingProfileVerifyEmailRetryAfterDuration')(
+                convertSecondsToTimeDuration({
+                  seconds: emailVerifyRateLimitInfo.secondsUntilNextEmailSubmit,
+                  unitLength: 1,
+                  messages: i18nStore.t(
+                    'convertSecondsToTimeDurationMessages'
+                  )(),
+                })
+              )
+            }}
+          </template>
+          <!-- 修改点击前 -->
+          <template v-else>
+            {{ i18nStore.t('settingProfileUpdatePasswordContentTitle')() }}
+          </template>
+        </ElButton>
+      </div>
+    </ConfirmContainer>
+  </div>
+</template>
+
+<style lang="scss" scoped></style>

--- a/vue3/src/views/setting/views/SettingProfile.vue/index.vue
+++ b/vue3/src/views/setting/views/SettingProfile.vue/index.vue
@@ -7,6 +7,7 @@ import UpdateUsername from './components/UpdateUsername.vue'
 import UpdateAvatar from './components/UpdateAvatar.vue'
 import UpdateEmail from './components/UpdateEmail.vue'
 import VerifyEmail from './components/VerifyEmail.vue'
+import UpdatePassword from './components/UpdatePassword.vue'
 
 const i18nStore = useI18nStore()
 useSeoMeta({
@@ -40,7 +41,9 @@ const authStore = useAuthStore()
         <!-- 圆角盒子 -->
         <div
           v-if="authStore.isValid"
-          class="mb-6 flow-root rounded-3xl bg-color-background-soft"
+          class="
+          transition-all duration-900 ease-in-out
+          mb-6 flow-root rounded-3xl bg-color-background-soft shadow-none hover:shadow-md dark:hover:shadow-black/60 hover:shadow-black/20"
         >
           <!-- 内容盒子 -->
           <div class="m-4">
@@ -51,7 +54,9 @@ const authStore = useAuthStore()
         <!-- 需登录 修改用户名 -->
         <div
           v-if="authStore.isValid"
-          class="mb-6 flow-root rounded-3xl bg-color-background-soft"
+          class="
+          transition-all duration-900 ease-in-out
+          mb-6 flow-root rounded-3xl bg-color-background-soft shadow-none hover:shadow-md dark:hover:shadow-black/60 hover:shadow-black/30"
         >
           <div class="m-4">
             <UpdateUsername></UpdateUsername>
@@ -60,7 +65,9 @@ const authStore = useAuthStore()
         <!-- 需登录 修改头像 -->
         <div
           v-if="authStore.isValid"
-          class="mb-6 flow-root rounded-3xl bg-color-background-soft"
+          class="
+          transition-all duration-900 ease-in-out
+          mb-6 flow-root rounded-3xl bg-color-background-soft shadow-none hover:shadow-md dark:hover:shadow-black/60 hover:shadow-black/30"
         >
           <div class="m-4">
             <UpdateAvatar></UpdateAvatar>
@@ -69,7 +76,9 @@ const authStore = useAuthStore()
         <!-- 需登录 修改邮箱 -->
         <div
           v-if="authStore.isValid"
-          class="mb-6 flow-root rounded-3xl bg-color-background-soft"
+          class="
+          transition-all duration-900 ease-in-out
+          mb-1 flow-root rounded-t-3xl bg-color-background-soft shadow-none hover:shadow-md dark:hover:shadow-black/60 hover:shadow-black/30"
         >
           <div class="m-4">
             <UpdateEmail></UpdateEmail>
@@ -78,10 +87,23 @@ const authStore = useAuthStore()
         <!-- 需登录 验证邮箱 -->
         <div
           v-if="authStore.isValid"
-          class="mb-6 flow-root rounded-3xl bg-color-background-soft"
+          class="
+          transition-all duration-900 ease-in-out
+          mb-1 flow-root rounded-none bg-color-background-soft shadow-none hover:shadow-md dark:hover:shadow-black/60 hover:shadow-black/30"
         >
           <div class="m-4">
             <VerifyEmail></VerifyEmail>
+          </div>
+        </div>
+        <!-- 需登录 修改密码 -->
+        <div
+          v-if="authStore.isValid"
+          class="
+          transition-all duration-900 ease-in-out
+          mb-6 flow-root rounded-b-3xl bg-color-background-soft shadow-none hover:shadow-md dark:hover:shadow-black/60 hover:shadow-black/30"
+        >
+          <div class="m-4">
+            <UpdatePassword></UpdatePassword>
           </div>
         </div>
       </div>

--- a/vue3/tailwind.config.js
+++ b/vue3/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 export default {
+  darkMode: 'class',
   content: [
     "./index.html",
     "./src/**/*.{vue,js,ts,jsx,tsx}",


### PR DESCRIPTION
- 参考 haruki 过往项目为个人页的卡片添加鼠标悬浮时的阴影过渡
- 合并修改类似逻辑的的“邮箱”、“密码”卡片为一个大圆角
- 新增“修改密码”组件，在个人信息页集成显示“修改密码“
- 添加了相关的中英文国际化文本