### PR TITLE
feat(Setting): Enhance user profile settings functionality

### DIFF
--- a/vue3/src/config/i18n/messages/setting/profile.ts
+++ b/vue3/src/config/i18n/messages/setting/profile.ts
@@ -19,6 +19,16 @@ export const i18nMessagesSettingPartProfilePart = {
     'zh-CN': () => '简介' as const,
     'zh-TW': () => '簡介' as const,
   },
+  settingProfileUpdateNameBioNamePlaceholder: {
+    'en-US': () => 'Write down the name you want to display' as const,
+    'zh-CN': () => '写下你希望展示的名称' as const,
+    'zh-TW': () => '寫下你希望展示的名稱' as const,
+  },
+  settingProfileUpdateNameBioBioPlaceholder: {
+    'en-US': () => 'Sketch your silhouette with words' as const,
+    'zh-CN': () => '用文字勾画你的剪影' as const,
+    'zh-TW': () => '用文字勾畫你的剪影' as const,
+  },
   // 设置页 个人信息 修改用户名
   settingProfileUpdateUsernameContentTitle: {
     'en-US': () => 'Modify Username' as const,

--- a/vue3/src/views/setting/views/SettingProfile.vue/components/UpdateAvatar.vue
+++ b/vue3/src/views/setting/views/SettingProfile.vue/components/UpdateAvatar.vue
@@ -288,7 +288,9 @@ const submit = mutation.mutateAsync
       :title="i18nStore.t('settingProfileUpdateAvatarDialogTitle')()"
       width="80%"
     >
-      <div class="flow-root rounded-t-3xl bg-color-background-soft">
+      <div
+        class="flow-root rounded-t-3xl bg-color-background-soft shadow-lg shadow-black/20"
+      >
         <!-- title -->
         <div class="my-0 hidden xl:my-4 xl:block">
           <span class="m-8 text-xl font-bold text-color-text-soft">{{
@@ -299,10 +301,11 @@ const submit = mutation.mutateAsync
           <div
             class="relative flex h-[600px] w-full justify-center overflow-hidden rounded-t-3xl xl:h-[400px] xl:rounded-3xl"
           >
+            <!-- 填充黑色空白 -->
             <img
               v-if="originalImage"
               :src="originalImage"
-              class="absolute left-0 top-0 h-full w-full scale-110 object-cover opacity-40 blur-lg"
+              class="absolute left-0 top-0 h-full w-full scale-110 object-cover opacity-60 blur-md"
             />
             <Cropper
               v-if="originalImage"
@@ -314,16 +317,14 @@ const submit = mutation.mutateAsync
               class="cropperBg"
             />
           </div>
-          <!-- 占位 div -->
-          <div class="h-[2px] w-full"></div>
         </div>
       </div>
       <!-- 再复制一份样式创建按钮 -->
       <div
-        class="mt-[2px] flow-root rounded-b-3xl bg-color-background-soft xl:mt-0"
+        class="mt-[2px] flow-root rounded-b-3xl bg-color-background-soft shadow-lg shadow-black/20 xl:mt-0"
       >
         <div
-          class="poto-setting-button-box not-center mb-4 mr-2 mt-2 xl:mr-8 xl:mt-4"
+          class="poto-setting-button-box not-center mb-4 mr-4 mt-2 xl:mr-8 xl:mt-4"
         >
           <span class="dialog-footer">
             <ElButton round @click="cropDialogVisible = false">{{

--- a/vue3/src/views/setting/views/SettingProfile.vue/components/UpdateNameBio.vue
+++ b/vue3/src/views/setting/views/SettingProfile.vue/components/UpdateNameBio.vue
@@ -162,7 +162,10 @@ const submit = mutation.mutateAsync
         <ElInput
           v-model="name"
           size="large"
-          class="poto-el-input-line"
+          :placeholder="
+            i18nStore.t('settingProfileUpdateNameBioNamePlaceholder')()
+          "
+          class="poto-el-input-line placeholder-inputText"
           @focus="
             // 输入框获取焦点时，设置为已编辑
             setEdited(true)
@@ -185,7 +188,10 @@ const submit = mutation.mutateAsync
           type="textarea"
           :autosize="{ minRows: 3, maxRows: 20 }"
           resize="none"
-          class="poto-el-input-line"
+          class="poto-el-input-line placeholder-textareaText"
+          :placeholder="
+            i18nStore.t('settingProfileUpdateNameBioBioPlaceholder')()
+          "
           @focus="
             // 输入框获取焦点时，设置为已编辑
             setEdited(true)
@@ -211,4 +217,14 @@ const submit = mutation.mutateAsync
   </div>
 </template>
 
-<style lang="scss" scoped></style>
+<style lang="scss" scoped>
+.el-input.placeholder-inputText :deep(input::placeholder) {
+  color: #777777 !important;
+  opacity: 1;
+}
+
+.el-textarea.placeholder-textareaText :deep(textarea::placeholder) {
+  color: #777777 !important;
+  opacity: 1; // 确保颜色不被降低透明度
+}
+</style>


### PR DESCRIPTION
- 对“名称”和“简介”添加占位文本并进行国际化处理
- 微调了头像裁剪对话框的样式，改进了模糊效果和阴影
- 为了让裁剪对话框在亮色模式下更容易显示，添加了阴影
---
### 占位文本：
<img width="835" height="368" alt="image" src="https://github.com/user-attachments/assets/18a59130-ca3b-44e0-beed-5d0f5f144965" />

---
### 裁剪间隔：

<img width="388" height="839" alt="image" src="https://github.com/user-attachments/assets/123e4c26-41d3-4e86-b48a-30ad40476e73" /><img width="388" height="839" alt="image" src="https://github.com/user-attachments/assets/0efb2e1d-df62-4083-bae7-285c12dced3e" />

放大查看，此处有 2px 的非空白间隔的溢出，来自未删除的占位 div

